### PR TITLE
Fix undefined 'history' reference

### DIFF
--- a/src/pages/Profile/index.tsx
+++ b/src/pages/Profile/index.tsx
@@ -54,7 +54,7 @@ function Profile({ userToken }: Readonly<IProfileProps>) {
 		} else {
 			navigate('/login')
 		}
-	}, [token, dispatch, history])
+        }, [token, dispatch, navigate])
 
 	const copyUid = () => {
 		navigator.clipboard.writeText(user.uid)


### PR DESCRIPTION
## Summary
- fix missing variable in Profile page

## Testing
- `npm run lint` *(fails: Cannot find package 'eslint-plugin-react')*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_68409f7e0c74832cbb8c9a7607a42503